### PR TITLE
Add incremental unzipping example, minor API suggestions

### DIFF
--- a/examples/src/Incremental.elm
+++ b/examples/src/Incremental.elm
@@ -45,28 +45,32 @@ update msg model =
         Decompress zip ->
             let
                 extracted =
+                    -- here we specify the number of files to attempt in this go
+                    -- Also a maximum size if we want to skip files that are twoo huge.
                     Zip.extract
                         { count = 1
                         , maxSize = Nothing
-                        , hasStringContent = 
+                        , hasStringContent =
                             \filename ->
-                                filename |> String.endsWith ".txt" 
+                                filename |> String.endsWith ".txt"
                         }
                         zip
-
-               
             in
             case extracted of
                 Zip.Done decompressedFiles ->
-                     -- do some work once everything is decompressed
+                    -- do some work once everything is decompressed
                     ( model, Cmd.none )
 
                 Zip.Loop zipped ->
+                    -- There is still more to decompress
                     let
-                         progress =
+                        -- retrieve some data representing the current level of progress
+                        progress =
                             Zip.progress zipped
                     in
                     ( model
+                      -- Here we're waiting till the next frame before doing any more work
+                      -- this allows us to report progress to the user incrementally
                     , Task.perform
                         (always (Decompress zipped))
                         (Process.sleep 1)

--- a/examples/src/Incremental.elm
+++ b/examples/src/Incremental.elm
@@ -38,9 +38,17 @@ update msg model =
             )
 
         FileLoaded bytes ->
-            ( { zipfile = Zip.read bytes }
-            , Cmd.none
-            )
+            case Zip.read bytes of
+                Nothing ->
+                    (model, Cmd.none)
+                Just zip ->
+                    let
+                        overview =
+                            Zip.overview zip
+                                |> Debug.log "overview"
+
+                    in
+                    update (Decompress zip) model
 
         Decompress zip ->
             let
@@ -59,6 +67,9 @@ update msg model =
             case extracted of
                 Zip.Done decompressedFiles ->
                     -- do some work once everything is decompressed
+                    let 
+                        _ = Debug.log "done" decompressedFiles
+                    in
                     ( model, Cmd.none )
 
                 Zip.Loop zipped ->
@@ -67,6 +78,7 @@ update msg model =
                         -- retrieve some data representing the current level of progress
                         progress =
                             Zip.progress zipped
+                                |> Debug.log "progress"
                     in
                     ( model
                       -- Here we're waiting till the next frame before doing any more work

--- a/examples/src/Incremental.elm
+++ b/examples/src/Incremental.elm
@@ -1,0 +1,95 @@
+module Incremental exposing (main)
+
+import Browser
+import Bytes
+import Bytes.Decode as Decode
+import Bytes.Encode as Encode
+import File
+import File.Select
+import Html exposing (Html, button, div, text)
+import Html.Events exposing (onClick)
+import Process
+import Task
+import Zip
+
+
+type alias Model =
+    { zipfile : Maybe Zip.ZipFile }
+
+
+type Msg
+    = SelectFileClicked
+    | FileSelected File.File
+    | FileLoaded Bytes.Bytes
+    | Decompress Zip.ZipFile
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        SelectFileClicked ->
+            ( model
+            , File.Select.file [ "application/zip" ] FileSelected
+            )
+
+        FileSelected file ->
+            ( model
+            , Task.perform FileLoaded (File.toBytes file)
+            )
+
+        FileLoaded bytes ->
+            ( { zipfile = Zip.read bytes }
+            , Cmd.none
+            )
+
+        Decompress zip ->
+            let
+                extracted =
+                    Zip.extract
+                        { count = 1
+                        , maxSize = Nothing
+                        , hasStringContent = 
+                            \filename ->
+                                filename |> String.endsWith ".txt" 
+                        }
+                        zip
+
+               
+            in
+            case extracted of
+                Zip.Done decompressedFiles ->
+                     -- do some work once everything is decompressed
+                    ( model, Cmd.none )
+
+                Zip.Loop zipped ->
+                    let
+                         progress =
+                            Zip.progress zipped
+                    in
+                    ( model
+                    , Task.perform
+                        (always (Decompress zipped))
+                        (Process.sleep 1)
+                    )
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ button [ onClick SelectFileClicked ] [ text "Upload file" ]
+        , text (Debug.toString model.zipfile)
+        ]
+
+
+main : Program () Model Msg
+main =
+    Browser.document
+        { init = \() -> ( { zipfile = Nothing }, Cmd.none )
+        , view =
+            \model ->
+                { title = "page"
+                , body = [ view model ]
+                }
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }

--- a/src/Zip.elm
+++ b/src/Zip.elm
@@ -1,8 +1,10 @@
 module Zip exposing
-    ( withoutCompression, withDeflateCompression
-    , Entry, stringEntry, bytesEntry, fileEntry
-    , ZipFile, readZipFile
+    ( uncompressed, compressed
+    , Entry, string, bytes, file
+    , ZipFile, overview, read
     , extractFile, extractStringFile
+    , extractAll, Content(..)
+    , extract, Step(..), progress
     , bytesToString
     )
 
@@ -11,19 +13,23 @@ module Zip exposing
 
 # Create Zip File
 
-@docs withoutCompression, withDeflateCompression
+@docs uncompressed, compressed
 
 
 # Create zip file entries
 
-@docs Entry, stringEntry, bytesEntry, fileEntry
+@docs Entry, string, bytes, file
 
 
 # Extract files from a zip file
 
-@docs ZipFile, readZipFile
+@docs ZipFile, overview, read
 
 @docs extractFile, extractStringFile
+
+@docs extractAll, Content
+
+@docs extract, Step, progress
 
 @docs bytesToString
 
@@ -49,11 +55,11 @@ type Entry
 
 {-| Create a string entry
 
-    stringEntry "foo.txt" "foo bar baz"
+    Zip.string "foo.txt" "foo bar baz"
 
 -}
-stringEntry : String -> String -> Entry
-stringEntry name content =
+string : String -> String -> Entry
+string name content =
     StringData { name = name, content = content }
 
 
@@ -61,23 +67,23 @@ stringEntry name content =
 
     import Bytes.Encode
 
-    stringEntry "bytes.bc" (Bytes.Encode.encode [])
+    Zip.bytes "bytes.bc" (Bytes.Encode.encode [])
 
 -}
-bytesEntry : String -> Bytes -> Entry
-bytesEntry name content =
+bytes : String -> Bytes -> Entry
+bytes name content =
     BytesData { name = name, content = content }
 
 
 {-| Create an entry from a `elm/file` `File`.
 -}
-fileEntry : File.File -> Task.Task x Entry
-fileEntry file =
+file : File.File -> Task.Task x Entry
+file fileEntry =
     let
         name =
-            File.name file
+            File.name fileEntry
     in
-    file
+    fileEntry
         |> File.toBytes
         |> Task.map (\content -> BytesData { name = name, content = content })
 
@@ -87,18 +93,18 @@ toFileRecord compression entry =
     let
         -- general note: when compression grows the size of the data (e.g. for small files)
         -- actually use no compression
-        helper name bytes =
+        helper name bytesContent =
             let
                 uncompressedSize =
-                    Bytes.width bytes
+                    Bytes.width bytesContent
 
                 compressedBytes =
                     case compression of
                         NoCompression ->
-                            bytes
+                            bytesContent
 
                         DeflateCompression ->
-                            Flate.deflate bytes
+                            Flate.deflate bytesContent
 
                 compressedSize =
                     Bytes.width compressedBytes
@@ -109,7 +115,7 @@ toFileRecord compression entry =
                     compressedBytes
 
                 else
-                    bytes
+                    bytesContent
             , uncompressedSize = uncompressedSize
             , compressedSize = min compressedSize uncompressedSize
             , compression =
@@ -118,16 +124,16 @@ toFileRecord compression entry =
 
                 else
                     NoCompression
-            , crc = Flate.crc32 bytes
+            , crc = Flate.crc32 bytesContent
             }
     in
     case entry of
         StringData { name, content } ->
             let
-                bytes =
+                bytesContent =
                     Encode.encode (Encode.string content)
             in
-            helper name bytes
+            helper name bytesContent
 
         BytesData { name, content } ->
             helper name content
@@ -135,27 +141,27 @@ toFileRecord compression entry =
 
 {-| Create a zip file without compressing any of the file contents
 
-    withoutCompression
-        [ stringEntry "foo.elm" "module Foo exposing (..)"
-        , stringEntry "bar.hs" "module Foo where"
+    Zip.uncompressed
+        [ Zip.string "foo.elm" "module Foo exposing (..)"
+        , Zip.string "bar.hs" "module Foo where"
         ]
 
 -}
-withoutCompression : List Entry -> Bytes
-withoutCompression entries =
+uncompressed : List Entry -> Bytes
+uncompressed entries =
     create NoCompression entries
 
 
 {-| Create a zip file, compressing file contents with the [DEFLATE](https://en.wikipedia.org/wiki/DEFLATE) algorithm
 
-    withDeflateCompression
-        [ stringEntry "foo.elm" "module Foo exposing (..)"
-        , stringEntry "bar.hs" "module Foo where"
+    Zip.compressed
+        [ Zip.string "foo.elm" "module Foo exposing (..)"
+        , Zip.string "bar.hs" "module Foo where"
         ]
 
 -}
-withDeflateCompression : List Entry -> Bytes
-withDeflateCompression entries =
+compressed : List Entry -> Bytes
+compressed entries =
     create DeflateCompression entries
 
 
@@ -176,24 +182,44 @@ type ZipFile
     = ZipFile ZipDecode.ZipFile
 
 
-readZipFile : Bytes -> Maybe ZipFile
-readZipFile buffer =
+{-| -}
+overview :
+    ZipFile
+    ->
+        List
+            { filename : String
+            , compressedSize : Int
+            , uncompressedSize : Int
+            }
+overview (ZipFile zip) =
+    List.map
+        (\header ->
+            { filename = header.fileName
+            , compressedSize = header.compressedSize
+            , uncompressedSize = header.uncompressedSize
+            }
+        )
+        zip.centrals
+
+
+read : Bytes -> Maybe ZipFile
+read buffer =
     ZipDecode.readZipFile buffer
         |> Maybe.map ZipFile
 
 
 extractFile : String -> ZipFile -> Maybe Bytes
 extractFile name (ZipFile zipfile) =
-    case Dict.get name zipfile.uncompressedFiles of
-        Just content ->
+    case match name zipfile.uncompressedFiles of
+        Just ( filename, content ) ->
             Just content
 
         Nothing ->
-            case Dict.get name zipfile.possiblyCompressedFiles of
+            case match name zipfile.possiblyCompressedFiles of
                 Nothing ->
                     Nothing
 
-                Just { header, compressedContent } ->
+                Just ( filename, { header, compressedContent } ) ->
                     case header.compressionMethod of
                         0 ->
                             Just compressedContent
@@ -210,16 +236,30 @@ extractFile name (ZipFile zipfile) =
                             Nothing
 
 
+match targetFilename files =
+    case files of
+        [] ->
+            Nothing
+
+        ( name, content ) :: remain ->
+            if targetFilename == name then
+                Just ( name, content )
+
+            else
+                match targetFilename files
+
+
 extractStringFile : String -> ZipFile -> Maybe String
 extractStringFile name zipfile =
     extractFile name zipfile
         |> Maybe.andThen bytesToString
 
 
-extractFiles : ZipFile -> Dict String Bytes
-extractFiles (ZipFile zipfile) =
+{-| -}
+extractAll : ZipFile -> Dict String Bytes
+extractAll (ZipFile zipfile) =
     let
-        folder key { header, compressedContent } accum =
+        folder ( key, { header, compressedContent } ) accum =
             case header.compressionMethod of
                 0 ->
                     Dict.insert key compressedContent accum
@@ -235,25 +275,133 @@ extractFiles (ZipFile zipfile) =
                 _ ->
                     accum
     in
-    Dict.foldl folder zipfile.uncompressedFiles zipfile.possiblyCompressedFiles
+    List.foldl folder (Dict.fromList zipfile.uncompressedFiles) zipfile.possiblyCompressedFiles
 
 
-extractFilesStep : Int -> ZipFile -> Decode.Step ZipFile (Dict String Bytes)
-extractFilesStep maxSize (ZipFile zipfile) =
-    case extractFilesStepHelp maxSize (Dict.toList zipfile.possiblyCompressedFiles) zipfile.uncompressedFiles of
-        Decode.Done uncompressed ->
-            Decode.Done uncompressed
+{-| -}
+progress : ZipFile -> { uncompressed : Int, compressed : Int, total : Int }
+progress (ZipFile zip) =
+    let
+        uncompressedCount =
+            List.length zip.uncompressedFiles
+
+        compressedCount =
+            List.length zip.possiblyCompressedFiles
+    in
+    { uncompressed = uncompressedCount
+    , compressed = compressedCount
+    , total = uncompressedCount + compressedCount
+    }
+
+
+{-| -}
+type Step
+    = Loop ZipFile
+    | Done (List ( String, Content ))
+
+
+{-| -}
+type Content
+    = StringContent String
+    | BytesContent Bytes
+    | Failed Bytes
+
+
+{-| This function will allow you to incrementally decompress a zip file.
+
+Check out the `examples/src/Incremental.elm` example for a working example but
+
+    Decompress zip ->
+        let
+            extracted =
+                -- here we specify the number of files to attempt in this go
+                --
+                Zip.extract
+                    { count = 1
+                    , maxSize = Nothing
+                    , hasStringContent =
+                        \filename ->
+                            filename |> String.endsWith ".txt"
+                    }
+                    zip
+
+
+        in
+        case extracted of
+            Zip.Done decompressedFiles ->
+                -- do some work once everything is decompressed
+                ( model, Cmd.none )
+
+            Zip.Loop zipped ->
+                -- There is still more to decompress
+                let
+                    -- retrieve some data representing the current level of progress
+                    progress =
+                        Zip.progress zipped
+                in
+                ( model
+                -- Here we're waiting till the next frame before doing any more work
+                -- this allows us to report progress to the user incrementally
+                , Task.perform
+                    (always (Decompress zipped))
+                    (Process.sleep 1)
+                )
+
+-}
+extract :
+    { maxSize : Maybe Int
+    , count : Int
+    , hasStringContent : String -> Bool
+    }
+    -> ZipFile
+    -> Step
+extract config (ZipFile zipfile) =
+    case extractHelp config 0 zipfile.possiblyCompressedFiles zipfile.uncompressedFiles of
+        Decode.Done extractedFiles ->
+            Done (interpretStringContent config extractedFiles [])
 
         Decode.Loop ( newPossiblyCompressed, newUncompressed ) ->
             { zipfile
-                | possiblyCompressedFiles = Dict.fromList newPossiblyCompressed
+                | possiblyCompressedFiles = newPossiblyCompressed
                 , uncompressedFiles = newUncompressed
             }
                 |> ZipFile
-                |> Decode.Loop
+                |> Loop
 
 
-extractFilesStepHelp maxSize possiblyCompressedFiles uncompressedFiles =
+interpretStringContent :
+    { maxSize : Maybe Int
+    , count : Int
+    , hasStringContent : String -> Bool
+    }
+    -> List ( String, Bytes )
+    -> List ( String, Content )
+    -> List ( String, Content )
+interpretStringContent config files captured =
+    case files of
+        [] ->
+            captured
+
+        ( filename, byteContent ) :: remain ->
+            if config.hasStringContent filename then
+                case bytesToString byteContent of
+                    Nothing ->
+                        interpretStringContent config
+                            remain
+                            (( filename, Failed byteContent ) :: captured)
+
+                    Just stringContent ->
+                        interpretStringContent config
+                            remain
+                            (( filename, StringContent stringContent ) :: captured)
+
+            else
+                interpretStringContent config
+                    remain
+                    (( filename, BytesContent byteContent ) :: captured)
+
+
+extractHelp config index possiblyCompressedFiles uncompressedFiles =
     case possiblyCompressedFiles of
         [] ->
             Decode.Done uncompressedFiles
@@ -261,29 +409,49 @@ extractFilesStepHelp maxSize possiblyCompressedFiles uncompressedFiles =
         ( key, { header, compressedContent } ) :: rest ->
             case header.compressionMethod of
                 0 ->
-                    extractFilesStepHelp maxSize rest (Dict.insert key compressedContent uncompressedFiles)
+                    extractHelp config
+                        index
+                        rest
+                        (( key, compressedContent ) :: uncompressedFiles)
 
                 8 ->
-                    if Bytes.width compressedContent < maxSize then
+                    let
+                        belowMaxSize =
+                            case config.maxSize of
+                                Nothing ->
+                                    True
+
+                                Just maxSize ->
+                                    Bytes.width compressedContent < maxSize
+                    in
+                    if index < config.count && belowMaxSize then
                         case Flate.inflate compressedContent of
                             Just inflated ->
-                                extractFilesStepHelp
-                                    (max 0 (maxSize - Bytes.width compressedContent))
+                                extractHelp
+                                    config
+                                    (index + 1)
                                     rest
-                                    (Dict.insert key inflated uncompressedFiles)
+                                    (( key, inflated ) :: uncompressedFiles)
 
                             Nothing ->
-                                Decode.Loop ( possiblyCompressedFiles, uncompressedFiles )
+                                let
+                                    _ =
+                                        Debug.log "failed to inflate" key
+                                in
+                                extractHelp
+                                    config
+                                    index
+                                    rest
+                                    uncompressedFiles
 
                     else
-                        extractFilesStepHelp
-                            maxSize
-                            rest
-                            uncompressedFiles
+                        Decode.Loop
+                            ( possiblyCompressedFiles, uncompressedFiles )
 
                 _ ->
-                    extractFilesStepHelp
-                        maxSize
+                    extractHelp
+                        config
+                        index
                         rest
                         uncompressedFiles
 


### PR DESCRIPTION
Hello!

I was messing around with `elm-zip` a few days ago and thought I'd propagate some of the changes I made back to your repo in case you were interested.

My main usecase is in incremental unzipping, so I added an example to the examples folder.  Basically it unzips one file, then  uses `Process.sleep` to make sure another frame is able to get through.

This PR also does the following:
1. Changes the internal file container from a `Dict` to a `List`.  This is to avoid a lot of converting back and forth from Dict to List when using `extract`.
2. Adds `extract` which is basically a version of your `extractFileStep` function, but also allows you to specify how many files to attempt to extract on this step.
3. Adds `progress` to see how many files still need to be extracted.
4. Adds `overview` to get some info from the zip files themselves.
5. Some slight renames in the API, (Hopefully I'm not overstepping my bounds here 😅 )

Let me know if there are any changes you disagree with, I'm happy to make adjustments!


